### PR TITLE
Update Gradle wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   repositories {
     mavenCentral()
     mavenLocal()
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
   }
 
   dependencies {
@@ -18,7 +18,7 @@ allprojects  {
 }
 
 wrapper {
-  gradleVersion = '5.5.1'
+  gradleVersion = '9.0.0-rc-1'
 }
 
 subprojects {
@@ -28,7 +28,7 @@ subprojects {
   repositories {
     mavenCentral()
     mavenLocal()
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
   }
 
   dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-1-all.zip


### PR DESCRIPTION
## Summary
- update wrapper script to use Gradle 9 release candidate
- switch Maven repository URLs to https

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: A problem occurred evaluating root project 'scape-editor'. > org/gradle/util/WrapUtil)*

------
https://chatgpt.com/codex/tasks/task_e_686f08f8acbc832bb019282d573021c4